### PR TITLE
Update RCS Build Aid for KSP 1.12.5

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -4,6 +4,13 @@ v1.0.6, January 2021:
 
 This document lists important changes between versions.
 
+== Version 1.0.7
+*Release date: TBD*
+
+* Update for KSP 1.12.5.
+* Replace removed Unity `GUIText` debug labels with `TextMesh` so the plugin
+  compiles against KSP 1.12.5's Unity assemblies.
+
 == Version 1.0.6
 *Release date: 31/01/2021*
 

--- a/Plugin/AssemblyInfo.cs
+++ b/Plugin/AssemblyInfo.cs
@@ -20,4 +20,4 @@ using System.Reflection;
 [assembly: AssemblyDescription("Aid tool for the placement of RCS thrusters.")]
 [assembly: AssemblyProduct("RCSBuildAid")]
 [assembly: AssemblyCopyright("Copyright © 2013-2020, Elián Hanisch. Distributed under the terms of the LGPLv3")]
-[assembly: AssemblyVersion("1.0.6.*")]
+[assembly: AssemblyVersion("1.0.7.*")]

--- a/Plugin/Debug.cs
+++ b/Plugin/Debug.cs
@@ -39,7 +39,7 @@ namespace RCSBuildAid
 #if DEBUG
     [KSPAddon(KSPAddon.Startup.Flight, false)]
 #endif
-    [RequireComponent(typeof(GUIText))]
+    [RequireComponent(typeof(TextMesh))]
     public class InFlightReadings : MonoBehaviour
     {
         Vessel vessel;
@@ -51,7 +51,7 @@ namespace RCSBuildAid
         double maxAcc;
 
         DebugVesselTree vesselTreeWindow;
-        GUIText guiText;
+        TextMesh guiText;
 
         void Start ()
         {
@@ -60,7 +60,7 @@ namespace RCSBuildAid
                 return;
             }
 
-            guiText = gameObject.GetComponent<GUIText> ();
+            guiText = gameObject.GetComponent<TextMesh> ();
             guiText.transform.position = new Vector3 (0.82f, 0.94f, 0f);
             vessel = FlightGlobals.ActiveVessel;
             guiText.text = "no vessel";
@@ -177,4 +177,3 @@ namespace RCSBuildAid
         }
     }
 }
-

--- a/Plugin/LineRenderer/VectorGraphic.cs
+++ b/Plugin/LineRenderer/VectorGraphic.cs
@@ -29,12 +29,12 @@ namespace RCSBuildAid
         protected float width;
 
         [SerializeField]
-        GUIText debugLabel;
+        TextMesh debugLabel;
 
         [Conditional("DEBUG")]
         void enableDebugLabel (bool v) {
             if (debugLabel != null) {
-                debugLabel.enabled = v;
+                debugLabel.gameObject.SetActive(v);
             }
         }
 
@@ -82,9 +82,9 @@ namespace RCSBuildAid
                 if (debugLabel == null) {
                     var obj = new GameObject ("VectorGraphic debug label");
                     obj.transform.parent = transform;
-                    debugLabel = obj.AddComponent<GUIText> ();
+                    debugLabel = obj.AddComponent<TextMesh> ();
                 }
-                debugLabel.enabled = true;
+                debugLabel.gameObject.SetActive(true);
                 debugLabel.transform.position = 
                     EditorLogic.fetch.editorCamera.WorldToViewportPoint (endPoint);
                 if (value.magnitude > 0f) {
@@ -98,7 +98,7 @@ namespace RCSBuildAid
                 }
             } else {
                 if (debugLabel != null) {
-                    debugLabel.enabled = false;
+                    debugLabel.gameObject.SetActive(false);
                 }
             }
         }

--- a/RCSBuildAid.version
+++ b/RCSBuildAid.version
@@ -6,12 +6,12 @@
     "VERSION": {
         "MAJOR": 1,
         "MINOR": 0,
-        "PATCH": 6
+        "PATCH": 7
     },
     "KSP_VERSION": {
         "MAJOR": 1,
-        "MINOR": 11,
-        "PATCH": 1
+        "MINOR": 12,
+        "PATCH": 5
     },
     "KSP_VERSION_MIN": {
         "MAJOR": 1,

--- a/RCSBuildAidToolbar/AssemblyInfo.cs
+++ b/RCSBuildAidToolbar/AssemblyInfo.cs
@@ -20,5 +20,5 @@ using System.Reflection;
 [assembly: AssemblyDescription("Aid tool for the placement of RCS thrusters.")]
 [assembly: AssemblyProduct("RCSBuildAid")]
 [assembly: AssemblyCopyright("Copyright © 2013-2020, Elián Hanisch. Distributed under the terms of the LGPLv3")]
-[assembly: AssemblyVersion("1.0.6.*")]
+[assembly: AssemblyVersion("1.0.7.*")]
 [assembly: KSPAssemblyDependency("Toolbar", 1, 0)]

--- a/README.adoc
+++ b/README.adoc
@@ -11,7 +11,7 @@ image::intro.jpg[width="600",align="center"]
 
 == Requirements
 
-* KSP version 1.11.x
+* KSP version 1.11.x - 1.12.x
 
 === Supported mods
 


### PR DESCRIPTION
## Summary

- update RCS Build Aid metadata/docs for KSP 1.12.x / 1.12.5
- replace removed Unity `GUIText` usage in debug labels with `TextMesh`
- bump assembly/version metadata to `1.0.7`

## Why

The current source still targets KSP 1.11.x in the README and fails to compile against KSP 1.12.5's Unity assemblies because `GUIText` has been removed. This keeps the change small and focused on source compatibility.

## Validation

Built locally on Linux with Mono against KSP `1.12.5.3190` managed assemblies:

```sh
BUILD="$PWD/bin/Release"
make "$BUILD/RCSBuildAid.dll" "$BUILD/RCSBuildAidToolbar.dll" \
  KSPDIR="/home/sean/.local/share/Steam/steamapps/common/Kerbal Space Program" \
  BUILD="$BUILD" \
  TOOLBAR_LIB="$PWD/Libraries" \
  GMCS="mcs -sdk:4.5"
```

Additional checks:

- `python -m json.tool RCSBuildAid.version`
- `monodis --assembly bin/Release/RCSBuildAid.dll` reports `Version: 1.0.7.*`
- `monodis --assembly bin/Release/RCSBuildAidToolbar.dll` reports `Version: 1.0.7.*`

I did not run an in-game smoke test; opening as draft so maintainers can decide whether runtime QA or release packaging changes are needed.
